### PR TITLE
Implement option to embed fonts

### DIFF
--- a/nimPDF/options.nim
+++ b/nimPDF/options.nim
@@ -3,12 +3,14 @@ type
     resourcesPath: seq[string]
     fontsPath: seq[string]
     imagesPath: seq[string]
+    embedFont*: bool
 
 proc newPDFOptions*(): PDFOptions =
   new(result)
   result.resourcesPath = @[]
   result.fontsPath = @[]
   result.imagesPath = @[]
+  result.embedFont = false
 
 proc getFontsPath*(opt: PDFOptions): seq[string] =
   result = opt.fontsPath
@@ -37,7 +39,14 @@ proc clearImagesPath*(opt: PDFOptions) =
 proc clearResourcesPath*(opt: PDFOptions) =
   opt.resourcesPath.setLen(0)
 
+proc setEmbedFont*(opt: PDFOptions, embedFont: bool) =
+  opt.embedFont = embedFont
+
+proc getEmbedFont*(opt: PDFOptions): bool =
+  result = opt.embedFont
+
 proc clearAllPath*(opt: PDFOptions) =
   opt.clearFontsPath()
   opt.clearImagesPath()
   opt.clearResourcesPath()
+  opt.setEmbedFont(false)

--- a/nimPDF/page.nim
+++ b/nimPDF/page.nim
@@ -231,7 +231,7 @@ proc putResources(doc: DocState): DictObj =
   let grads = putGradients(doc.xref, doc.gradients)
   let exts  = putExtGStates(doc.xref, doc.ExtGStates)
   let imgs  = putImages(doc.xref, doc.images)
-  let fonts = putFonts(doc.xref, doc.fontMan.fontList)
+  let fonts = putFonts(doc.xref, doc.fontMan.fontList, doc.opts.getEmbedFont())
 
   result = newDictObj()
   doc.xref.add(result)
@@ -702,7 +702,7 @@ proc drawText*(self: ContentBase; x,y: float64; text: string) =
 
   if font.subType == FT_TRUETYPE:
     var utf8 = replace_invalid(text)
-    self.put("BT ",f2s(xx)," ",f2s(yy)," Td <",font.EscapeString(utf8),"> Tj ET")
+    self.put("BT ",f2s(xx)," ",f2s(yy)," Td <",font.EscapeString(utf8, self.state.opts.getEmbedFont()),"> Tj ET")
   else:
     self.put("BT ",f2s(xx)," ",f2s(yy)," Td (",escapeString(text),") Tj ET")
 
@@ -719,7 +719,7 @@ proc drawVText*(self: ContentBase; x,y: float64; text: string) =
   var xx = self.fromUser(x)
   var yy = self.state.vPoint(y)
   let utf8 = replace_invalid(text)
-  let cid = font.EscapeString(utf8)
+  let cid = font.EscapeString(utf8, self.state.opts.getEmbedFont())
 
   self.put("BT")
   var i = 0
@@ -762,7 +762,7 @@ proc showText*(self: ContentBase, text:string) =
 
   if font.subType == FT_TRUETYPE:
     var utf8 = replace_invalid(text)
-    self.put("<",font.EscapeString(utf8),"> Tj")
+    self.put("<",font.EscapeString(utf8, self.state.opts.getEmbedFont()),"> Tj")
   else:
     self.put("(",escapeString(text),") Tj")
 

--- a/nimPDF/resources.nim
+++ b/nimPDF/resources.nim
@@ -77,14 +77,14 @@ proc putBase14Fonts(xref: Pdfxref, font: Font): DictObj =
     elif fon.encoding == ENC_WINANSI: fn.addName("Encoding", "WinAnsiEncoding")
   result = fn
 
-proc putTrueTypeFonts(xref: Pdfxref, font: Font, seed: int): DictObj =
+proc putTrueTypeFonts(xref: Pdfxref, font: Font, seed: int, embedFont: bool): DictObj =
   let fon = TTFont(font)
   let subsetTag  = makeSubsetTag(seed)
 
   let widths   = fon.GenerateWidths() #don't change this order
   let ranges   = fon.GenerateRanges() #coz they sort CH2GID differently
   let desc     = fon.GetDescriptor()
-  let buf      = fon.GetSubsetBuffer(subsetTag)
+  let buf      = fon.GetSubsetBuffer(subsetTag, embedFont)
   let Length1  = buf.len
   let psName   = subsetTag & desc.postscriptName
 
@@ -155,13 +155,13 @@ end"""
 
   result = fn
 
-proc putFonts*(xref: Pdfxref, fonts: seq[Font]): DictObj =
+proc putFonts*(xref: Pdfxref, fonts: seq[Font], embedFont: bool): DictObj =
   var seed = fromBase26("NIMPDF")
   if fonts.len > 0: result = newDictObj()
   var fn: DictObj
 
   for fon in fonts:
     if fon.subType == FT_BASE14: fn = xref.putBase14Fonts(fon)
-    if fon.subType == FT_TRUETYPE: fn = xref.putTrueTypeFonts(fon, seed)
+    if fon.subType == FT_TRUETYPE: fn = xref.putTrueTypeFonts(fon, seed, embedFont)
     result.addElement("F" & $fon.ID, fn)
     inc(seed)


### PR DESCRIPTION
This PR adds the ability to **embed fonts** directly into the generated PDF files.

Embedding increases the PDF file size slightly, but enables much better post-processing compatibility - especially when copying text or handling non-ASCII characters.

This also solves my issue from 2021 :) https://github.com/jangko/nimpdf/issues/39

---

### Example

To enable font embedding, simply set the new option:

```nim
var opts = newPDFOptions()
opts.setEmbedFont(true)

var doc = newPDF(opts)
```

---

### Notes
I've aimed to keep the implementation as non-intrusive as possible, but it will always load the font cache in the `makeTTFont()`. 